### PR TITLE
[FIX] fixes the sender name of the mail

### DIFF
--- a/Plugin/Frontend/Magento/Contact/Model/Mail.php
+++ b/Plugin/Frontend/Magento/Contact/Model/Mail.php
@@ -94,10 +94,7 @@ class Mail
                     ]
                 )
                 ->setTemplateVars($replyTo)
-                ->setFrom([
-                    'email' => $this->contactsConfig->emailRecipient(),
-                    'name' => $this->contactsConfig->emailSender()
-                ])
+                ->setFromByScope($this->contactsConfig->emailSender())
                 ->addTo($replyToEmail)
                 ->setReplyTo(
                     $this->contactsConfig->emailRecipient(),


### PR DESCRIPTION
Hello !

i found that issue, that the module does not provide the correct sender-information to the `TransportBuilder`.
So the Sendername will be always the ident key. (e.g. `custom2`)

This PR will fix this.